### PR TITLE
Extract lifecycle component from presenter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
 //    implementation project(path: ':library')
     implementation 'com.github.vicidroiddev:amalia:0.0.2'
+    implementation('com.github.bumptech.glide:glide:4.9.0') {
+        exclude group: "com.android.support"
+    }
 
     // Required to use androidx.lifecycle.DefaultLifecycleObserver
     implementation "android.arch.lifecycle:common-java8:$lifecycleVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,11 +42,12 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.1.2-alpha01'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.2-alpha01'
 
-//    implementation project(path: ':library')
-    implementation 'com.github.vicidroiddev:amalia:0.0.2'
     implementation('com.github.bumptech.glide:glide:4.9.0') {
         exclude group: "com.android.support"
     }
+
+    implementation project(path: ':library')
+//    implementation 'com.github.vicidroiddev:amalia:0.0.2'
 
     // Required to use androidx.lifecycle.DefaultLifecycleObserver
     implementation "android.arch.lifecycle:common-java8:$lifecycleVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:dist="http://schemas.android.com/apk/distribution"
-          package="com.vicidroid.amalia.sample">
+        xmlns:dist="http://schemas.android.com/apk/distribution"
+        package="com.vicidroid.amalia.sample">
 
-    <dist:module dist:instant="true"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <!--
+    Allows Glide to monitor connectivity status and restart failed requests if users go from a
+    a disconnected to a connected network state.
+    -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
+    <dist:module dist:instant="true" />
 
     <application
             android:allowBackup="true"
@@ -13,13 +20,24 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
         <activity
+                android:name=".imagelist.ImageListActivity"
+                android:label="@string/title_activity_image_list"
+                android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+        </activity>
+        <activity
                 android:name=".MainActivity"
                 android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+<!--            <intent-filter>-->
+<!--                <action android:name="android.intent.action.MAIN" />-->
 
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
+<!--                <category android:name="android.intent.category.LAUNCHER" />-->
+<!--            </intent-filter>-->
         </activity>
     </application>
 

--- a/app/src/main/java/com/vicidroid/amalia/sample/imagelist/ImageListActivity.kt
+++ b/app/src/main/java/com/vicidroid/amalia/sample/imagelist/ImageListActivity.kt
@@ -1,0 +1,43 @@
+package com.vicidroid.amalia.sample.imagelist
+
+import android.os.Bundle
+import android.widget.Toast
+import com.google.android.material.snackbar.Snackbar
+import androidx.appcompat.app.AppCompatActivity
+import com.bumptech.glide.Glide
+import com.vicidroid.amalia.ext.componentProvider
+import com.vicidroid.amalia.sample.R
+
+import kotlinx.android.synthetic.main.activity_image_list.*
+import kotlinx.android.synthetic.main.content_image_list.image_list_image_1 as image1
+import kotlinx.android.synthetic.main.content_image_list.image_list_image_2 as image2
+import kotlinx.android.synthetic.main.content_image_list.image_list_image_3 as image3
+import kotlinx.android.synthetic.main.content_image_list.image_list_image_4 as image4
+import kotlinx.android.synthetic.main.content_image_list.image_list_image_5 as image5
+
+class ImageListActivity : AppCompatActivity() {
+
+  private val imageListComponent by componentProvider { ImageListComponent() }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_image_list)
+    setSupportActionBar(toolbar)
+
+    imageListComponent.propagateStatesTo(::onImageListStateChanged)
+  }
+
+  private fun onImageListStateChanged(state: ImageListState) {
+    // PRETEND LEGACY CODE WHICH IS STUCK IN ACTIVITY
+
+    when (state) {
+      is ImageListState.UrlsReady -> {
+        Glide.with(this).load(state.imageUrls[0]).centerInside().into(image1)
+        Glide.with(this).load(state.imageUrls[1]).centerInside().into(image2)
+        Glide.with(this).load(state.imageUrls[2]).centerInside().into(image3)
+        Glide.with(this).load(state.imageUrls[3]).centerInside().into(image4)
+        Glide.with(this).load(state.imageUrls[4]).centerInside().into(image5)
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/vicidroid/amalia/sample/imagelist/ImageListComponent.kt
+++ b/app/src/main/java/com/vicidroid/amalia/sample/imagelist/ImageListComponent.kt
@@ -1,0 +1,30 @@
+package com.vicidroid.amalia.sample.imagelist
+
+import android.widget.Toast
+import androidx.lifecycle.LifecycleOwner
+import com.vicidroid.amalia.core.LifecycleComponent
+import java.util.*
+
+class ImageListComponent : LifecycleComponent<ImageListState>() {
+
+    var masterList = listOf(
+        "https://cdn.motor1.com/images/mgl/lPoV1/s3/renders-of-cars-with-tiny-wheels.jpg",
+        "https://s1.cdn.autoevolution.com/images/news/ferrari-812-spider-rendered-probably-wont-happen-115479_1.jpg",
+        "https://amp.businessinsider.com/images/5a57df4ef421493e028b4752-960-720.jpg",
+        "https://cmsimages-alt.kbb.com/content/dam/kbb-editorial/make/mazda/mazda3/2019/first-review/01-2019-Mazda3-first-review.jpg",
+        "https://cdn.bmwblog.com/wp-content/uploads/2018/08/BMW-M5-Competition-test-drive99-830x553.jpg"
+    )
+
+    var imageList = emptyList<String>()
+
+    override fun onCreate(owner: LifecycleOwner) {
+        if (imageList.isEmpty()) {
+            Toast.makeText(applicationContext, "No previous image list, shuffling...", Toast.LENGTH_SHORT).show()
+            imageList = masterList.shuffled(Random(System.currentTimeMillis()))
+        } else {
+            Toast.makeText(applicationContext, "Restored image list", Toast.LENGTH_SHORT).show()
+        }
+
+        pushState(ImageListState.UrlsReady(imageList))
+    }
+}

--- a/app/src/main/java/com/vicidroid/amalia/sample/imagelist/ImageListState.kt
+++ b/app/src/main/java/com/vicidroid/amalia/sample/imagelist/ImageListState.kt
@@ -1,0 +1,7 @@
+package com.vicidroid.amalia.sample.imagelist
+
+import com.vicidroid.amalia.core.ViewState
+
+sealed class ImageListState : ViewState {
+    class UrlsReady(val imageUrls: List<String>) : ImageListState()
+}

--- a/app/src/main/res/layout/activity_image_list.xml
+++ b/app/src/main/res/layout/activity_image_list.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".imagelist.ImageListActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="@style/AppTheme.AppBarOverlay">
+
+        <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorPrimary"
+                app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <include layout="@layout/content_image_list" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_image_list.xml
+++ b/app/src/main/res/layout/content_image_list.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            tools:context=".imagelist.ImageListActivity"
+            tools:showIn="@layout/activity_image_list">
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+
+        <ImageView
+                android:id="@+id/image_list_image_1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
+        <ImageView
+                android:id="@+id/image_list_image_2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
+        <ImageView
+                android:id="@+id/image_list_image_3"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
+        <ImageView
+                android:id="@+id/image_list_image_4"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
+        <ImageView
+                android:id="@+id/image_list_image_5"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
+
+    </LinearLayout>
+
+
+</ScrollView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="fab_margin">16dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="title_home">Home</string>
     <string name="title_dashboard">Dashboard</string>
     <string name="title_notifications">Notifications</string>
+    <string name="title_activity_image_list">ImageListActivity</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,4 +8,13 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.3.30'
     repositories {
         mavenCentral()
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.5.0-alpha12'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 18 13:13:16 PST 2019
+#Fri Apr 19 12:12:30 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -37,7 +37,7 @@ android {
 dependencies {
     def lifecycleVersion = "1.1.1"
     def kotlinVersion = "1.3.0"
-    def androidXVersion = "1.0.0"
+    def androidXVersion = "1.0.2"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 

--- a/library/src/main/java/com/vicidroid/amalia/core/BasePresenter.kt
+++ b/library/src/main/java/com/vicidroid/amalia/core/BasePresenter.kt
@@ -44,10 +44,6 @@ abstract class BasePresenter<S : ViewState, E : ViewEvent>
 
     val viewDelegateLifecycleOwner = viewDelegate.lifecycleOwner
 
-    // Allow this class to listen for lifecycle events from the view delegate.
-    // Just override a lifecycle method, example #onResume()
-    viewDelegateLifecycleOwner.lifecycle.addObserver(this)
-
     // Observe view events sent from the view delegate
     viewDelegate
         .eventLiveData()

--- a/library/src/main/java/com/vicidroid/amalia/core/BasePresenter.kt
+++ b/library/src/main/java/com/vicidroid/amalia/core/BasePresenter.kt
@@ -23,15 +23,6 @@ abstract class BasePresenter<S : ViewState, E : ViewEvent>
     viewEventPropagatorLiveData.observe(lifecycleOwner!!, Observer { presenter.onViewEvent(it) })
   }
 
-  /**
-   * Propagate states sent by this presenter to another observer.
-   * This may be of use when adding amalia to legacy code or in a parent child presenter hierarchy.
-   */
-  fun propagateStatesTo(observer: (S) -> Unit) {
-    lifecycleOwner ?: error("You must call bind() prior to propagating states. Alternatively you must provide a lifecycle.")
-    stateLiveData().observe(lifecycleOwner!!, Observer { observer(it) })
-  }
-
   private fun processViewEvent(event: E) {
     onViewEvent(event)
     viewEventPropagatorLiveData.value = event

--- a/library/src/main/java/com/vicidroid/amalia/core/LifecycleComponent.kt
+++ b/library/src/main/java/com/vicidroid/amalia/core/LifecycleComponent.kt
@@ -1,0 +1,77 @@
+package com.vicidroid.amalia.core
+
+import android.content.Context
+import androidx.annotation.CallSuper
+import androidx.annotation.UiThread
+import androidx.annotation.WorkerThread
+import androidx.lifecycle.*
+import com.vicidroid.amalia.ui.BaseViewDelegate
+
+/**
+ * Backed by Android's ViewModel in order to easily survive configuration changes.
+ */
+abstract class LifecycleComponent<S : ViewState>
+    : ViewModel(),
+    DefaultLifecycleObserver {
+
+    lateinit var applicationContext: Context
+
+    /**
+     * Upon setting an owner this component will be added as an observer to receive lifecycle events.
+     * When the owner is set to null we remove the observer.
+     * In theory we should not need to remove the observer, but just in case we do it here.
+     * See: https://github.com/googlecodelabs/android-lifecycles/issues/5
+     */
+    var lifecycleOwner: LifecycleOwner? = null
+        set(value) {
+            value?.lifecycle?.addObserver(this)
+                ?: field?.lifecycle?.removeObserver(this)
+
+            field = value
+        }
+
+    private val viewStateLiveData = MutableLiveData<S>()
+
+    fun stateLiveData(): LiveData<S> = viewStateLiveData
+
+    /**
+     * This may be of use for legacy code where one wishes to separate some data loading logic
+     * from a fragment and reap the benefits of components for lifecycle aware behaviour without
+     * manipulating the view logic.
+     */
+    open fun propagateStatesTo(lifecycleOwner: LifecycleOwner, observer: (S) -> Unit) {
+        this.lifecycleOwner = lifecycleOwner
+        lifecycleOwner.lifecycle.addObserver(this)
+        stateLiveData().observe(lifecycleOwner, Observer { observer(it) })
+    }
+
+    /**
+     * Sends a [state] for the view delegate to process in order to reflect UI changes.
+     * This must be called from the main thread.
+     */
+    @UiThread
+    fun pushState(state: S) {
+        viewStateLiveData.value = state
+    }
+
+    /**
+     * Sends a [state] for the view delegate to process in order to reflect UI changes.
+     * This may be called from a background thread.
+     */
+    @WorkerThread
+    fun pushStateOnMainLooper(state: S) {
+        viewStateLiveData.postValue(state)
+    }
+
+    @CallSuper
+    override fun onDestroy(owner: LifecycleOwner) {
+        // When the provided lifecycle owner goes through onDestroy, let's ensure we avoid any leaking.
+        lifecycleOwner = null
+    }
+
+    override fun onCleared() {
+        //https://github.com/googlecodelabs/android-lifecycles/issues/5
+        // We do not have to remove the observer to the LifecycleRegistry according to the above
+        // If this changes we should clear out our observer manually.
+    }
+}

--- a/library/src/main/java/com/vicidroid/amalia/core/LifecycleComponent.kt
+++ b/library/src/main/java/com/vicidroid/amalia/core/LifecycleComponent.kt
@@ -5,7 +5,6 @@ import androidx.annotation.CallSuper
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
 import androidx.lifecycle.*
-import com.vicidroid.amalia.ui.BaseViewDelegate
 
 /**
  * Backed by Android's ViewModel in order to easily survive configuration changes.
@@ -39,10 +38,20 @@ abstract class LifecycleComponent<S : ViewState>
      * from a fragment and reap the benefits of components for lifecycle aware behaviour without
      * manipulating the view logic.
      */
+    @Deprecated(message = "Leverage a provider which injects a lifecycle", replaceWith = ReplaceWith("propagateStatesTo(observer)"))
     open fun propagateStatesTo(lifecycleOwner: LifecycleOwner, observer: (S) -> Unit) {
         this.lifecycleOwner = lifecycleOwner
         lifecycleOwner.lifecycle.addObserver(this)
         stateLiveData().observe(lifecycleOwner, Observer { observer(it) })
+    }
+
+    /**
+     * Propagate pushes states to another via the provided observer.
+     * This may be of use when adding amalia to legacy code or in a parent child presenter hierarchy.
+     */
+    fun propagateStatesTo(observer: (S) -> Unit) {
+        lifecycleOwner ?: error("You must call bind() prior to propagating states. Alternatively you must provide a lifecycle.")
+        stateLiveData().observe(lifecycleOwner!!, Observer { observer(it) })
     }
 
     /**

--- a/library/src/main/java/com/vicidroid/amalia/ext/LifecycleComponentProvider.kt
+++ b/library/src/main/java/com/vicidroid/amalia/ext/LifecycleComponentProvider.kt
@@ -1,0 +1,47 @@
+package com.vicidroid.amalia.ext
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProviders
+import com.vicidroid.amalia.core.BasePresenter
+import com.vicidroid.amalia.core.LifecycleComponent
+
+
+inline fun <reified C : LifecycleComponent<*>> Fragment.componentProvider(crossinline componentCreator: () -> C) =
+    componentProvider(this, componentCreator)
+
+inline fun <reified P : LifecycleComponent<*>> FragmentActivity.presenterProvider(crossinline presenterCreator: () -> P) =
+    componentProvider(this, presenterCreator)
+
+inline fun <reified P : LifecycleComponent<*>> AppCompatActivity.componentProvider(crossinline presenterCreator: () -> P) =
+    componentProvider(this, presenterCreator)
+
+
+inline fun <reified C : LifecycleComponent<*>> componentProvider(
+    lifecycleOwner: LifecycleOwner,
+    crossinline componentCreator: () -> C
+) = lazy(LazyThreadSafetyMode.NONE) {
+
+    @Suppress("UNCHECKED_CAST")
+    val factory = object : ViewModelProvider.Factory {
+        override fun <VM : ViewModel> create(componentClazz: Class<VM>): VM {
+            return (componentCreator() as VM).also { component ->
+                (component as C).let {
+                    component.applicationContext = lifecycleOwner.applicationContext
+                    component.lifecycleOwner = lifecycleOwner
+                }
+            }
+        }
+    }
+
+    when (lifecycleOwner) {
+        is FragmentActivity -> ViewModelProviders.of(lifecycleOwner, factory)[C::class.java]
+        is Fragment -> ViewModelProviders.of(lifecycleOwner, factory)[C::class.java]
+        else -> error("Unsupported lifecycle owner detected.")
+    }
+}

--- a/library/src/main/java/com/vicidroid/amalia/ext/LifecycleOwnerExt.kt
+++ b/library/src/main/java/com/vicidroid/amalia/ext/LifecycleOwnerExt.kt
@@ -1,0 +1,13 @@
+package com.vicidroid.amalia.ext
+
+import android.content.Context
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.LifecycleOwner
+
+val LifecycleOwner.applicationContext: Context
+  get() = when (this) {
+    is FragmentActivity -> this.application
+    is Fragment -> this.activity!!.application
+    else -> error("Unable to obtain context due to unsupported lifecycle owner.")
+  }

--- a/library/src/main/java/com/vicidroid/amalia/ext/PresenterProvider.kt
+++ b/library/src/main/java/com/vicidroid/amalia/ext/PresenterProvider.kt
@@ -74,7 +74,7 @@ inline fun <reified P : BasePresenter<*, *>> presenterProvider(
     is FragmentActivity -> ViewModelProviders.of(lifecycleOwner, factory)[P::class.java]
     is Fragment -> ViewModelProviders.of(lifecycleOwner, factory)[P::class.java]
     else -> error("Unsupported lifecycle owner detected.")
-  }
+  }.also { p -> p.lifecycleOwner = lifecycleOwner }
 }
 
 /**

--- a/library/src/main/java/com/vicidroid/amalia/ext/PresenterProvider.kt
+++ b/library/src/main/java/com/vicidroid/amalia/ext/PresenterProvider.kt
@@ -77,13 +77,6 @@ inline fun <reified P : BasePresenter<*, *>> presenterProvider(
   }
 }
 
-val LifecycleOwner.applicationContext: Context
-  get() = when (this) {
-    is FragmentActivity -> this.application
-    is Fragment -> this.activity!!.application
-    else -> error("Unable to obtain context due to unsupported lifecycle owner.")
-  }
-
 /**
  * Workaround for reified types which allows the use of [presenterProvider] in Java.
  * Moreover, this will support constructor arguments in presenters.

--- a/library/src/test/java/com/vicidroid/amalia/BasePresenterTest.kt
+++ b/library/src/test/java/com/vicidroid/amalia/BasePresenterTest.kt
@@ -204,7 +204,7 @@ class BasePresenterTest : TestCase() {
       childPresenter.propagateStatesTo(::onStatePropagated)
     }
 
-    fun onStatePropagated(state: ViewState) {}
+    fun onStatePropagated(@Suppress("UNUSED_PARAMETER") state: ViewState) {}
   }
 
   class FakeViewDelegate(lifecycleOwner: LifecycleOwner, rootView: View)

--- a/library/src/test/java/com/vicidroid/amalia/LifecycleComponentTest.kt
+++ b/library/src/test/java/com/vicidroid/amalia/LifecycleComponentTest.kt
@@ -1,0 +1,118 @@
+package com.vicidroid.amalia
+
+import android.app.Application
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import com.nhaarman.mockitokotlin2.*
+import com.vicidroid.amalia.core.LifecycleComponent
+import com.vicidroid.amalia.core.ViewState
+import com.vicidroid.amalia.ext.componentProvider
+import junit.framework.TestCase
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class LifecycleComponentTest : TestCase() {
+
+  // Ensure live data emits immediately.
+  @get:Rule
+  var rule: TestRule = InstantTaskExecutorRule()
+
+  @Mock
+  lateinit var activity: FragmentActivity
+
+  @Mock
+  lateinit var application: Application
+
+  @Mock
+  lateinit var viewModelStore: ViewModelStore
+
+  @Mock
+  lateinit var lifecycleOwner: LifecycleOwner
+
+  lateinit var lifecycle: LifecycleRegistry
+
+  lateinit var mockedComponent: FakeComponent
+
+  lateinit var componentViaProvider: LifecycleComponent<ViewState>
+
+  @Before
+  fun init() {
+    MockitoAnnotations.initMocks(this)
+
+    lifecycle = spy(LifecycleRegistry(lifecycleOwner))
+    mockedComponent = spy(FakeComponent())
+
+    whenever(lifecycleOwner.lifecycle).thenReturn(lifecycle)
+
+    whenever(activity.lifecycle).thenReturn(lifecycle)
+    whenever(activity.application).thenReturn(application)
+    whenever(activity.viewModelStore).thenReturn(viewModelStore)
+
+    componentViaProvider = activity.componentProvider { FakeComponent() }.value
+  }
+
+  @Test
+  fun `lifecycle dependencies mocked correctly`() {
+    assertEquals(lifecycle, activity.lifecycle)
+    assertEquals(componentViaProvider.lifecycleOwner, activity)
+  }
+
+  @Test
+  fun `component is added as lifecycle observer when using component provider`() {
+    verify(lifecycle).addObserver(componentViaProvider)
+    assertEquals(lifecycle.observerCount, 1)
+  }
+
+  @Test
+  fun `component is not added as observer to lifecycle callbacks without provider`() {
+    val component = FakeComponent()
+     verify(lifecycle, never()).addObserver(component)
+  }
+
+  @Test
+  fun `component receives lifecycle callbacks`() {
+    mockedComponent.lifecycleOwner = lifecycleOwner
+
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    verify(mockedComponent).onCreate(lifecycleOwner)
+
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+    verify(mockedComponent).onStart(lifecycleOwner)
+
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    verify(mockedComponent).onResume(lifecycleOwner)
+
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    verify(mockedComponent).onPause(lifecycleOwner)
+
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+    verify(mockedComponent).onStop(lifecycleOwner)
+
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    verify(mockedComponent).onDestroy(lifecycleOwner)
+  }
+
+  @Test
+  fun `component destroys lifecycle owner`() {
+    mockedComponent.lifecycleOwner = lifecycleOwner
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    assertNull(mockedComponent.lifecycleOwner)
+  }
+
+  class FakeComponent : LifecycleComponent<ViewState>()
+}


### PR DESCRIPTION
For better legacy code integration. Useful if one does not wish to refactor the view logic in an activity or fragment to a view delegate. 